### PR TITLE
new section Git is the new standard

### DIFF
--- a/index.html
+++ b/index.html
@@ -755,7 +755,58 @@ show       Show various types of objects
 				</div>
 				
 	    </div>
+		  <div class="span-24 section">
+					<div class="args">
+						<span class="lang hg">hg</span>
+						<span class="lang bzr">bzr</span>
+						<span class="lang svn">svn</span>
+						<span class="lang perforce">perforce</span>
+					</div>
+			
+	        <h2>
+          <a name="git-is-standard" href="#git-is-standard">Git is the new standard</a>
+	        </h2>
 	
+					<div class="contents">
+						<div class="text">
+	                                          No other distributed version control system can list so many major free software projects on its
+                                                  &quote;used-by&quote; page. This means that Git seems to work for these projects and
+                                                  that large group of free software developers were able to agree on Git.
+						</div>
+					
+						<div class="text">
+                                                   But this also means that all the developers participating in those many projects have learned to
+                                                   use Git and have installed Git on their machines. So if you want others to contribute to your
+                                                   project, it is much more likely that they do so, if you use the same DVCS that they are already
+                                                   familiar with.
+						</div>
+
+						<div class="text">
+                                                    Major projects that use Git:
+                                                    <ul>
+                                                      <li>Android</li>
+                                                      <li>Apache Software Foundation (At least they officially mirror to Git.)</li>
+                                                      <li>Debian (almost all packages, if a DVCS is used)</li>
+                                                      <li>Drupal</li>
+                                                      <li>Eclipse</li>
+                                                      <li>Fedora</li>
+                                                      <li>Gnome</li>
+                                                      <li>KDE</li>
+                                                      <li>The Linux Kernel of course ...</li>
+                                                      <li>Perl</li>
+                                                      <li>PHP (decided to migrate to Git)</li>
+                                                      <li>PostgreSQL</li>
+                                                      <li>Qt</li>
+                                                      <li>Ruby on Rails (and it seems the Ruby world in general prefers Git)</li>
+                                                      <li>all freedesktop.org projects, including X.org</li>
+                                                      <li>and <a href="https://git.wiki.kernel.org/articles/g/i/t/GitProjects_8074.html">many many more ...</a></li>
+                                                    </ul>
+                                                    Compare this with lists of projects using
+                                                    <a href="http://mercurial.selenic.com/wiki/ProjectsUsingMercurial">Mercurial</a> or
+                                                    <a href="http://wiki.bazaar.canonical.com/WhoUsesBzr">Bazaar</a>.
+						</div>
+				</div>	
+	    </div>
 	
 		<!-- 
 			THINGS GIT IS STILL NOT GOOD AT 


### PR DESCRIPTION
Text of the new section:

No other distributed version control system can list so many major free software projects on its "e;used-by"e; page. This means that GIT seems to work for these projects and that large group of free software developers were able to agree on GIT.
But this also means that all the developers participating in those many projects have learned to use GIT and have installed GIT on their machines. So if you want others to contribute to your project, it is much more likely that they do so, if you use the same DVCS that they are already familiar with.
Major projects that use GIT:
- Android
- Apache Software Foundation (At least they officially mirror to GIT.)
- Debian (almost all packages, if a DVCS is used)
- Drupal
- Eclipse
- Fedora
- Gnome
- Kde
- The Linux Kernel of course ...
- Perl
- PHP (decided to migrate to GIT)
- PostgreSQL
- Qt
- Ruby on Rails (and it seems the Ruby world in general prefers GIT)
- all freedesktop.org projects, including X.org
- and many many more ...
  Compare this with lists of projects using Mercurial or Bazaar.
