### PR TITLE
Fixes grammar mistake

### DIFF
--- a/index.html
+++ b/index.html
@@ -671,7 +671,7 @@
         
 				<div class="contents">
 					<div class="text">										
-						This did not used to be true&mdash;early in Git's life, it was not really 
+						This did not use to be true&mdash;early in Git's life, it was not really 
 						an SCM so much as a bunch of tools that let you do versioned filesystem 
 						work in a distributed manner.  However, today, the command set and 
 						learning curve of Git are pretty similar to any other SCM, and even 


### PR DESCRIPTION
I stumbled across a link to this site but saw that it had expired last month, so I found it on Internet archive. Noticed this grammar mistake (did not _use_ should be infinitive not past, the past is already in the 'did') so figured I might try and correct it. Though last commit here was 5 years ago, I don't know if this is still maintained.
